### PR TITLE
docs(sage_bbb): enhance installation guide and update BigBlueButton setup references

### DIFF
--- a/docs/source/big_blue_button/conf_tools.rst
+++ b/docs/source/big_blue_button/conf_tools.rst
@@ -1,3 +1,5 @@
+.. _conf_tools:
+
 Obtaining the Security Salt
 ===========================
 

--- a/docs/source/big_blue_button/index.rst
+++ b/docs/source/big_blue_button/index.rst
@@ -5,7 +5,7 @@ Big Blue Button
 
 .. toctree::
    :maxdepth: 2
-   :caption: Big Blue Button
+   :caption: Comprehensive Guide to Big Blue Button Setup on Your Server
 
    installation
    conf_tools

--- a/docs/source/getting_started/index.rst
+++ b/docs/source/getting_started/index.rst
@@ -5,8 +5,8 @@ Getting Started
 
 .. toctree::
    :maxdepth: 2
-   :caption: Getting Started
+   :caption: Learn how to integrate and utilize the `sage_bbb` package effectively
 
    introduction
-   features
    installation
+   features

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -1,6 +1,9 @@
 Installation Guide
 ==================
 
+.. note:: 
+   To work with ``python-sage-bbb``, ensure that BigBlueButton (BBB) is set up on a server and that you have obtained your security salt key. Refer to the :ref:`conf_tools` for setting up BBB.
+
 Step 1: Create a Virtual Environment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/getting_started/introduction.rst
+++ b/docs/source/getting_started/introduction.rst
@@ -3,4 +3,4 @@ Introduction
 
 BigBlueButton (BBB) is an open-source web conferencing system designed for online learning. It provides real-time sharing of audio, video, slides, chat, and screen, and offers tools for teachers to engage with their students. BigBlueButton is widely used in educational institutions and businesses for virtual classrooms, online meetings, and remote collaboration.
 
-Our package, ``sage_bbb``, offers a streamlined way to interact with the BigBlueButton API, making it easy to manage meetings, recordings, and configurations programmatically. By utilizing this package, you can integrate BigBlueButton’s powerful features into your own applications, automate routine tasks, and enhance your virtual collaboration experiences.
+The ``sage_bbb`` package offers a streamlined way to interact with the BigBlueButton API, making it easy to manage meetings, recordings, and configurations programmatically. By utilizing this package, BigBlueButton’s powerful features can be integrated into applications, routine tasks can be automated, and virtual collaboration experiences can be enhanced.


### PR DESCRIPTION
- Added a note in the installation guide to inform users about setting up BigBlueButton on a server and obtaining the security salt key.
- Included a reference link to the BigBlueButton configuration tools section for detailed setup instructions.
- Updated the `index.rst` caption to "Comprehensive Guide to Big Blue Button Setup on Your Server" for better clarity.