### PR TITLE
build(sage_bbb): Add run.py to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,7 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# local files
+run.py
+*/run.py


### PR DESCRIPTION
Included run.py and */run.py in the .gitignore file to prevent local script files from being tracked by Git. This ensures that development-specific or environment-specific scripts are not mistakenly committed to the repository.