### PR TITLE
feat: add client_settings_override parameter to create_meeting()

### DIFF
--- a/sage_bbb/services/meetings.py
+++ b/sage_bbb/services/meetings.py
@@ -53,6 +53,7 @@ class Meetings:
         meeting_id: str,
         attendee_pw: str,
         moderator_pw: str,
+        client_settings_override: str = None,
         **kwargs: Any,
     ) -> "Meeting":
         """
@@ -63,6 +64,7 @@ class Meetings:
             meeting_id (str): The unique identifier for the meeting.
             attendee_pw (str): The password for attendees.
             moderator_pw (str): The password for moderators.
+            client_settings_override(str): Overrides the html5-client settings.yml
             **kwargs: Additional optional parameters for the meeting.
 
         Returns:
@@ -86,8 +88,23 @@ class Meetings:
             "moderatorPW": moderator_pw,
             **kwargs,
         }
-        logger.info("Creating meeting with params: %s", params)
-        response = self.client.send_request("create", params)
+        if client_settings_override:
+            headers = {"Content-Type": "application/xml"}
+            data = (
+                '<modules>\n<module name="clientSettingsOverride">\n'
+                + client_settings_override
+                + "\n</module>\n</modules>"
+            )
+            logger.info(
+                "Creating meeting with params: %s; headers: %s; data: %s",
+                params,
+                headers,
+                data,
+            )
+            response = self.client.send_request("create", params, data, headers)
+        else:
+            logger.info("Creating meeting with params: %s", params)
+            response = self.client.send_request("create", params)
         response_dict = self.client.parse_response(response.content)
         logger.info("Meeting created successfully with ID: %s", meeting_id)
         return MeetingFactory.create_meeting(response_dict)


### PR DESCRIPTION
This allows overriding the html5-client settings.yml options in the create call, for this to work `allowOverrideClientSettingsOnCreateCall` in `/etc/bigbluebutton/bbb-web.properties` needs to be set to `true`.

[Documentation](https://docs.bigbluebutton.org/development/api/#clientsettingsoverride) of the feature.


`pytest` ran 0 tests, I didn't find any either. The linter complains about having more than five arguments in the function, any ideas how i could implement this without the extra argument?

This should however not break compatibility since the behaviour stays the same as before if the client_settings_override parameter is not passed.

Regarding `data`:
- the ` <![CDATA[` and `]]>` could be included in the literal string since it doesn't change
- alternatively the whole string including the `<module>` parts could be supplied by the caller

is there any preference on how thats handled?

When the technical details are resolved I'm gonna open another pull request to add the feature to the docs